### PR TITLE
References: prevent error when a non-UTF8 cfg file exists in workspace

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [unreleased] -
 
+### Fixed
+
+  - references: prevent error when a non -UTF8 cfg file exists in the workspace
+
 ## [0.17.0] - 2025-11-26
 
 ### Fixed

--- a/server/src/buildoutls/buildout.py
+++ b/server/src/buildoutls/buildout.py
@@ -1021,11 +1021,12 @@ async def parse(
   else:
     document = ls.workspace.get_text_document(uri)
     try:
-      fp = io.StringIO(document.source)
-    except IOError:
+      src = document.source
+    except (UnicodeDecodeError, IOError):
       if not allow_errors:
         raise
-      fp = io.StringIO("")
+      src = ""
+    fp = io.StringIO(src)
   parsed = await _parse(
     fp,
     uri,

--- a/server/src/buildoutls/tests/conftest.py
+++ b/server/src/buildoutls/tests/conftest.py
@@ -124,3 +124,24 @@ async def template(server) -> Any:
     uri="file:///buildout.cfg",
   )
   return await parsed.getTemplate(server, "template.in")
+
+
+@pytest.fixture(params=[True, False])
+def bad_encoding_file(request: pytest.FixtureRequest):
+  """Fixture that optionally creates a bad_encoding.cfg file.
+
+  Parameterized to run tests both with and without the file.
+  """
+  import pathlib
+
+  profiles_dir = pathlib.Path(__file__).resolve().parents[4] / "profiles"
+  bad_file = None
+  if request.param:
+    bad_file = profiles_dir / "bad_encoding.cfg"
+    bad_file.write_bytes(b"\xff\xfe[section]\noption = value\n")
+
+  try:
+    yield request.param
+  finally:
+    if bad_file:
+      bad_file.unlink()

--- a/server/src/buildoutls/tests/test_references.py
+++ b/server/src/buildoutls/tests/test_references.py
@@ -1,3 +1,4 @@
+import pytest
 from lsprotocol.types import (
   Position,
   Range,
@@ -10,6 +11,7 @@ from pygls.lsp.server import LanguageServer
 from ..server import lsp_references
 
 
+@pytest.mark.usefixtures("bad_encoding_file")
 async def test_references_on_section_header(server: LanguageServer):
   references = await lsp_references(
     server,
@@ -33,6 +35,7 @@ async def test_references_on_section_header(server: LanguageServer):
   )
 
 
+@pytest.mark.usefixtures("bad_encoding_file")
 async def test_references_on_option_definition(server: LanguageServer):
   # ${referenced_section1:value1} is referenced once
   references = await lsp_references(
@@ -61,6 +64,7 @@ async def test_references_on_option_definition(server: LanguageServer):
   assert references == []
 
 
+@pytest.mark.usefixtures("bad_encoding_file")
 async def test_references_on_option_reference(server: LanguageServer):
   references = await lsp_references(
     server,
@@ -77,6 +81,7 @@ async def test_references_on_option_reference(server: LanguageServer):
   )
 
 
+@pytest.mark.usefixtures("bad_encoding_file")
 async def test_references_on_section_reference(server: LanguageServer):
   references = await lsp_references(
     server,
@@ -93,6 +98,7 @@ async def test_references_on_section_reference(server: LanguageServer):
   )
 
 
+@pytest.mark.usefixtures("bad_encoding_file")
 async def test_references_from_parts(server: LanguageServer):
   references = await lsp_references(
     server,


### PR DESCRIPTION
Fixes buildout.parse() failing on non-UTF-8 encoded .cfg files by adding proper error handling and parametrized tests.