### PR TITLE
hover: fix crash when hovering on jinja section names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Instructions
+
+## Running Tests
+
+### Server Tests
+
+To run all server tests, use `tox` from the server folder:
+
+```bash
+cd server
+tox
+```
+
+This is slow and generate lots of output, to run a specific test file or test function with pytest directly:
+
+```bash
+cd server
+uv run pytest src/buildoutls/tests/test_hover.py -v
+uv run pytest src/buildoutls/tests/test_hover.py::test_hover_jinja_section_name -v
+```
+
+Note: Test requirements need to be installed first:
+
+```bash
+cd server
+uv pip install -r test-requirements.txt
+```
+
+Also, make sure the linter is OK, using:
+
+```bash
+cd server
+ruff check src
+ruff format --diff src
+mypy .
+pylint --disable=all --enable=unused-variable,unreachable,duplicate-key,unused-import src
+```

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [unreleased] -
 
+### Fixed
+
+  - hover: fix crash when hovering on jinja section names like `[{{ section }}]`
+
 ## [0.17.1] - 2025-12-22
 
 ### Fixed

--- a/server/src/buildoutls/server.py
+++ b/server/src/buildoutls/server.py
@@ -729,8 +729,9 @@ async def lsp_hover(
   hover_text = ""
   if symbol:
     if symbol.kind == buildout.SymbolKind.SectionDefinition:
-      assert symbol.current_section
-      hover_text = symbol.current_section.documentation
+      if symbol.current_section_name:
+        if current_section := symbol._buildout.get(symbol.current_section_name):
+          hover_text = current_section.documentation
     elif symbol.kind == buildout.SymbolKind.BuildoutOptionKey:
       if symbol.current_option_name and symbol.current_section_recipe:
         if option := symbol.current_section_recipe.options.get(

--- a/server/src/buildoutls/tests/test_hover.py
+++ b/server/src/buildoutls/tests/test_hover.py
@@ -90,3 +90,17 @@ command = echo install section1
     )
     assert hover is not None
     assert hover.contents == ""
+
+
+async def test_hover_jinja_section_name(server: LanguageServer):
+  # hovering on a jinja section name like [{{ section }}] should not crash
+  hover = await lsp_hover(
+    server,
+    TextDocumentPositionParams(
+      text_document=TextDocumentIdentifier(
+        uri="file:///diagnostics/jinja-sections.cfg"
+      ),
+      position=Position(line=6, character=3),  # on [{{ section }}]
+    ),
+  )
+  assert hover is not None


### PR DESCRIPTION
## Summary

Fix crash when hovering over section headers containing jinja expressions like `[{{ section }}]`.

## Problem

When hovering on a jinja section name, the hover handler would crash with a `KeyError` because the literal section name (e.g., `{{ section }}`) doesn't exist in the buildout dictionary.

## Solution

Safely handle this case by:
1. Checking if `current_section_name` is not `None`
2. Using `.get()` to look up the section instead of direct dictionary access

## Changes

- `server/src/buildoutls/server.py` - Fix the hover handler
- `server/src/buildoutls/tests/test_hover.py` - Add test case
- `server/CHANGELOG.md` - Add changelog entry